### PR TITLE
Add Spoofax cask

### DIFF
--- a/Casks/spoofax-nightly.rb
+++ b/Casks/spoofax-nightly.rb
@@ -1,5 +1,6 @@
 cask 'spoofax-nightly' do
-  version '2.6.0-SNAPSHOT'
+  version :latest
+  sha256 :no_check
 
   url 'http://buildfarm.metaborg.org/job/metaborg/job/spoofax-releng/job/master/lastSuccessfulBuild/artifact/dist/spoofax/eclipse/spoofax-macosx-x64-jre.tar.gz'
   name 'Spoofax'

--- a/Casks/spoofax-nightly.rb
+++ b/Casks/spoofax-nightly.rb
@@ -1,4 +1,4 @@
-cask 'spoofax' do
+cask 'spoofax-nightly' do
   version '2.6.0-SNAPSHOT'
 
   url 'http://buildfarm.metaborg.org/job/metaborg/job/spoofax-releng/job/master/lastSuccessfulBuild/artifact/dist/spoofax/eclipse/spoofax-macosx-x64-jre.tar.gz'

--- a/Casks/spoofax-nightly.rb
+++ b/Casks/spoofax-nightly.rb
@@ -1,0 +1,9 @@
+cask 'spoofax' do
+  version '2.6.0-SNAPSHOT'
+
+  url 'http://buildfarm.metaborg.org/job/metaborg/job/spoofax-releng/job/master/lastSuccessfulBuild/artifact/dist/spoofax/eclipse/spoofax-macosx-x64-jre.tar.gz'
+  name 'Spoofax'
+  homepage 'https://www.metaborg.org/'
+
+  app 'spoofax.app'
+end

--- a/Casks/spoofax.rb
+++ b/Casks/spoofax.rb
@@ -1,0 +1,11 @@
+cask 'spoofax' do
+  version '2.5.9'
+  sha256 '62dc7c3a9052acaa3bdb8524279859b9c9a75d7b68a9202cf242aba6b2ad5860'
+
+  url "https://artifacts.metaborg.org/service/local/repositories/releases/content/org/metaborg/org.metaborg.spoofax.eclipse.dist/#{version}/org.metaborg.spoofax.eclipse.dist-#{version}-macosx-x64-jre.tar.gz"
+  appcast 'https://github.com/metaborg/spoofax/releases.atom'
+  name 'Spoofax'
+  homepage 'https://www.metaborg.org/'
+
+  app 'spoofax.app'
+end


### PR DESCRIPTION
This migrates the cask I had merged to the primary Cask repository to live here instead, and adds another cask to install the latest nightly build of Spoofax.