### PR TITLE
Rename installed app for nightly builds

### DIFF
--- a/Casks/spoofax-nightly.rb
+++ b/Casks/spoofax-nightly.rb
@@ -6,5 +6,5 @@ cask 'spoofax-nightly' do
   name 'Spoofax'
   homepage 'https://www.metaborg.org/'
 
-  app 'spoofax.app'
+  app 'spoofax.app', target: 'spoofax-nightly.app'
 end


### PR DESCRIPTION
This allows both the stable and nightly builds to be installed alongside each other when using Cask installations.