### PR TITLE
Fix StrategoXT dependency

### DIFF
--- a/strategoxt.rb
+++ b/strategoxt.rb
@@ -7,7 +7,7 @@ class Strategoxt < Formula
   url "http://artifacts.metaborg.org/service/local/repositories/releases/content/org/metaborg/strategoxt-distrib/#{version}/strategoxt-distrib-#{version}-bin.tar"
   sha256 "ffb9eb4784e633da3a27cba72655e49f8667f8936eeeea7f86e263255748fad6"
 
-  depends_on :openjdk
+  depends_on :openjdk@8
 
   def install
     # the ordering is sensitive here, if you get this wrong,

--- a/strategoxt.rb
+++ b/strategoxt.rb
@@ -7,7 +7,7 @@ class Strategoxt < Formula
   url "http://artifacts.metaborg.org/service/local/repositories/releases/content/org/metaborg/strategoxt-distrib/#{version}/strategoxt-distrib-#{version}-bin.tar"
   sha256 "ffb9eb4784e633da3a27cba72655e49f8667f8936eeeea7f86e263255748fad6"
 
-  depends_on :java
+  depends_on :openjdk
 
   def install
     # the ordering is sensitive here, if you get this wrong,


### PR DESCRIPTION
Upon updating this Cask, I get the following warning:
```
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
```
This is the suggested fix. If I'd know on what version of Java it depends specifically, this could be specified.